### PR TITLE
Component | Donut: Half Donut Label Placement

### DIFF
--- a/packages/dev/src/examples/misc/donut/half-donut-full-height/index.tsx
+++ b/packages/dev/src/examples/misc/donut/half-donut-full-height/index.tsx
@@ -29,6 +29,8 @@ export const component = (): JSX.Element => {
         duration={0}
         arcWidth={80}
         angleRange={currentAngleRange}
+        centralLabel="Central Label"
+        centralSubLabel="Sub-label"
       />
     </VisSingleContainer>
   )

--- a/packages/dev/src/examples/misc/donut/half-donut-with-labels/index.tsx
+++ b/packages/dev/src/examples/misc/donut/half-donut-with-labels/index.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { VisSingleContainer, VisDonut } from '@unovis/react'
+import { DONUT_HALF_ANGLE_RANGE_TOP } from '@unovis/ts'
+
+export const title = 'Half Donut: Labels'
+export const subTitle = 'Testing the label offsets'
+export const component = (): JSX.Element => {
+  const data = [3, 2, 5, 4, 0, 1]
+
+  return (
+    <VisSingleContainer style={{ height: '100%' }} >
+      <VisDonut
+        value={d => d}
+        data={data}
+        padAngle={0.02}
+        duration={0}
+        arcWidth={80}
+        angleRange={DONUT_HALF_ANGLE_RANGE_TOP}
+        centralLabel='Central Label'
+        centralSubLabel='Central Sub Label'
+        centralLabelsOffsetY={-24}
+      />
+    </VisSingleContainer>
+  )
+}

--- a/packages/ts/src/components/donut/config.ts
+++ b/packages/ts/src/components/donut/config.ts
@@ -42,6 +42,12 @@ export interface DonutConfigInterface<Datum> extends ComponentConfigInterface {
   showBackground?: boolean;
   /** Background angle range. When undefined, the value will be taken from `angleRange`. Default: `undefined` */
   backgroundAngleRange?: [number, number];
+
+  /** Central labels horizontal offset in pixels. Default: `undefined` */
+  centralLabelsOffsetX?: number;
+
+  /** Central labels vertical offset in pixels. Default: `undefined` */
+  centralLabelsOffsetY?: number;
 }
 
 export const DonutDefaultConfig: DonutConfigInterface<unknown> = {
@@ -62,4 +68,6 @@ export const DonutDefaultConfig: DonutConfigInterface<unknown> = {
   emptySegmentAngle: 0.5 * Math.PI / 180,
   showBackground: true,
   backgroundAngleRange: undefined,
+  centralLabelsOffsetX: undefined,
+  centralLabelsOffsetY: undefined,
 }

--- a/packages/ts/src/components/donut/index.ts
+++ b/packages/ts/src/components/donut/index.ts
@@ -161,17 +161,36 @@ export class Donut<Datum> extends ComponentCore<Datum[], DonutConfigInterface<Da
       .call(removeArc, duration)
 
     // Label
+    const labelTextAnchor = isHalfDonutRight ? 'start' : isHalfDonutLeft ? 'end' : 'middle'
     this.centralLabel
-      .attr('transform', translate)
       .attr('dy', config.centralSubLabel ? '-0.55em' : null)
+      .style('text-anchor', labelTextAnchor)
       .text(config.centralLabel ?? null)
 
     this.centralSubLabel
-      .attr('transform', translate)
       .attr('dy', config.centralLabel ? '0.55em' : null)
+      .style('text-anchor', labelTextAnchor)
       .text(config.centralSubLabel ?? null)
 
     if (config.centralSubLabelWrap) wrapSVGText(this.centralSubLabel, innerRadius * 1.9)
+
+    // Label placement
+    const { centralLabelsOffsetX, centralLabelsOffsetY } = config
+    const labelTranslateX = (centralLabelsOffsetX || 0) + translateX
+    let labelTranslateY = (centralLabelsOffsetY || 0) + translateY
+
+    // Special case label placement for half donut
+    if (isVerticalHalfDonut && centralLabelsOffsetX === undefined && centralLabelsOffsetY === undefined) {
+      const halfDonutLabelOffsetY = isHalfDonutTop
+        ? -this.centralSubLabel.node().getBoundingClientRect().height
+        : isHalfDonutBottom
+          ? this.centralLabel.node().getBoundingClientRect().height
+          : 0
+      labelTranslateY = halfDonutLabelOffsetY + translateY
+    }
+    const labelTranslate = `translate(${labelTranslateX},${labelTranslateY})`
+    this.centralLabel.attr('transform', labelTranslate)
+    this.centralSubLabel.attr('transform', labelTranslate)
 
     // Background
     this.arcBackground.attr('class', s.background)


### PR DESCRIPTION
This PR contains a simple solution to the half donut label placement problem that also could be used in the general case of donuts. Thank you @rokotyan for this [suggestion](https://github.com/ExaForce/unovis/pull/8/files#r1876723977)!

<img width="863" alt="image" src="https://github.com/user-attachments/assets/bf120d76-fccc-43cd-92c1-7e8b90c8575c">

If we will ultimately be doing text size estimation/measuring, then the changes in the other PR

 * https://github.com/ExaForce/unovis/pull/8

may not make sense to add yet.

Proposed plan:

 * Merge this PR to add the config options
 * Later do a separate PR that adds a more complex and robust solution that involves measuring/estimating the size of text