### PR TITLE
Fix/stacked bar negative values

### DIFF
--- a/packages/dev/src/examples/xy-components/scatter/scatter-with-line/index.tsx
+++ b/packages/dev/src/examples/xy-components/scatter/scatter-with-line/index.tsx
@@ -3,6 +3,7 @@ import { VisXYContainer, VisScatter, VisAxis, VisLine } from '@unovis/react'
 
 import { XYDataRecord } from '@src/utils/data'
 import { ExampleViewerDurationProps } from '@src/components/ExampleViewer/index'
+import type { WithOptional } from '@unovis/ts/lib/types/misc'
 
 export const title = 'Scatter with Line'
 export const subTitle = 'And undefined segments'
@@ -11,7 +12,7 @@ export const component = (props: ExampleViewerDurationProps): JSX.Element => {
     (d: XYDataRecord) => d.y,
   ]
 
-  const data: XYDataRecord[] = [
+  const data: WithOptional<XYDataRecord, 'y'>[] = [
     { x: 0, y: 9.4 },
     { x: 1, y: 8.6 },
     { x: 2, y: undefined },
@@ -25,7 +26,7 @@ export const component = (props: ExampleViewerDurationProps): JSX.Element => {
     { x: 14, y: 5.2 },
   ]
   return (
-    <VisXYContainer<XYDataRecord> data={data} margin={{ top: 5, left: 5 }} xDomain={[-1, 15]}>
+    <VisXYContainer data={data} margin={{ top: 5, left: 5 }} xDomain={[-1, 15]}>
       <VisScatter x={d => d.x} y={accessors} duration={props.duration}/>
       <VisLine x={d => d.x} y={accessors} duration={props.duration}/>
       <VisAxis type='x' numTicks={15} tickFormat={(x: number) => `${x}`} duration={props.duration}/>

--- a/packages/dev/src/examples/xy-components/stacked-bar/positive-negative-values/index.tsx
+++ b/packages/dev/src/examples/xy-components/stacked-bar/positive-negative-values/index.tsx
@@ -1,0 +1,27 @@
+import React, { useRef } from 'react'
+import { VisXYContainer, VisStackedBar, VisAxis, VisTooltip, VisCrosshair } from '@unovis/react'
+
+import { XYDataRecord, generateXYDataRecords } from '@src/utils/data'
+import { ExampleViewerDurationProps } from '@src/components/ExampleViewer/index'
+
+export const title = 'Stacked Bar: Negative Values'
+export const subTitle = 'Positive and Negative Stack'
+export const component = (props: ExampleViewerDurationProps): JSX.Element => {
+  const tooltipRef = useRef(null)
+  const data = generateXYDataRecords(15)
+  const accessors = [
+    (d: XYDataRecord) => (d.y1 || 0) - 3,
+    (d: XYDataRecord, i: number) => i % 4 ? d.y : -d.y,
+    (d: XYDataRecord, i: number) => i % 2 ? d.y1 : -(d.y1 as number),
+  ]
+
+  return (
+    <VisXYContainer<XYDataRecord> data={data} margin={{ top: 5, left: 5 }}>
+      <VisStackedBar x={d => d.x} y={accessors} duration={props.duration}/>
+      <VisAxis type='x' numTicks={3} tickFormat={(x: number) => `${x}ms`} duration={props.duration}/>
+      <VisAxis type='y' tickFormat={(y: number) => `${y}bps`} duration={props.duration}/>
+      <VisCrosshair template={(d: XYDataRecord) => `${d.x}`} />
+      <VisTooltip ref={tooltipRef} />
+    </VisXYContainer>
+  )
+}

--- a/packages/dev/src/utils/data.ts
+++ b/packages/dev/src/utils/data.ts
@@ -6,7 +6,7 @@ export const randomNumberGenerator = new Seedramdon('unovis')
 
 export type XYDataRecord = {
   x: number;
-  y: number | undefined;
+  y: number;
   y1?: number;
   y2?: number;
 }

--- a/packages/ts/src/components/area/index.ts
+++ b/packages/ts/src/components/area/index.ts
@@ -65,7 +65,7 @@ export class Area<Datum> extends XYComponentCore<Datum, AreaConfigInterface<Datu
     const areaDataX = data.map((d, i) => this.xScale(getNumber(d, config.x, i)))
 
     const stacked = getStackedData(data, config.baseline, yAccessors, this._prevNegative)
-    this._prevNegative = stacked.map(s => !!s.negative)
+    this._prevNegative = stacked.map(s => !!s.isMostlyNegative)
     const stackedData: AreaDatum[][] = stacked.map(
       arr => arr.map(
         (d, j) => ({

--- a/packages/ts/src/components/stacked-bar/types.ts
+++ b/packages/ts/src/components/stacked-bar/types.ts
@@ -1,5 +1,5 @@
 export type StackedBarDataRecord<D> = D & {
+  _index: number;
   _stacked: [number, number];
-  _negative: boolean;
   _ending: boolean;
 }

--- a/packages/ts/src/types/data.ts
+++ b/packages/ts/src/types/data.ts
@@ -2,4 +2,4 @@
 export type GenericDataRecord = Record<string, unknown>
 
 /** Extension of a numbers array that carries additional information required for plotting stacked data */
-export type StackValuesRecord = Array<[number, number]> & { negative?: boolean; ending?: boolean }
+export type StackValuesRecord = Array<[number, number]> & { isMostlyNegative: boolean }

--- a/packages/ts/src/utils/data.ts
+++ b/packages/ts/src/utils/data.ts
@@ -263,13 +263,13 @@ export function getStackedData<Datum> (
     return (average === 0 && Array.isArray(prevNegative)) ? prevNegative[j] : average < 0
   })
 
-  const stackedData: StackValuesRecord[] = acs.map(() => [])
+  const stackedData = acs.map(() => [] as StackValuesRecord)
   data.forEach((d, i) => {
     let positiveStack = baselineValues[i]
     let negativeStack = baselineValues[i]
     acs.forEach((a, j) => {
       const value = getNumber(d, a, i) || 0
-      if (!isNegativeStack[j]) {
+      if (value >= 0) {
         stackedData[j].push([positiveStack, positiveStack += value])
       } else {
         stackedData[j].push([negativeStack, negativeStack += value])
@@ -279,18 +279,8 @@ export function getStackedData<Datum> (
 
   // Fill in additional stack information
   stackedData.forEach((stack, i) => {
-    stack.negative = isNegativeStack[i]
+    stack.isMostlyNegative = isNegativeStack[i]
   })
-
-  stackedData.filter(s => s.negative)
-    .forEach((s, i, arr) => {
-      s.ending = i === arr.length - 1
-    })
-
-  stackedData.filter(s => !s.negative)
-    .forEach((s, i, arr) => {
-      s.ending = i === arr.length - 1
-    })
 
   return stackedData
 }


### PR DESCRIPTION
Fixes Stacked Bar rendering when the dataset has both positive and negative values returned by a single accessor function https://github.com/f5/unovis/issues/521.

### Before
<img width="754" alt="image" src="https://github.com/user-attachments/assets/36b3fbc1-efdd-45c5-96c5-9461a56bbbeb" />


### After
<img width="768" alt="image" src="https://github.com/user-attachments/assets/fdca96f1-3166-4bad-83b7-3d4ed51022b1" />
