### PR TITLE
Container | XY: Handle edge cases when `scaleByDomain` is `true`

### DIFF
--- a/packages/dev/src/examples/xy-components/area/basic-area-narrow-domain/index.tsx
+++ b/packages/dev/src/examples/xy-components/area/basic-area-narrow-domain/index.tsx
@@ -1,0 +1,30 @@
+import React, { useRef } from 'react'
+import { VisXYContainer, VisArea, VisAxis, VisTooltip, VisCrosshair, VisLine } from '@unovis/react'
+
+import { XYDataRecord, generateXYDataRecords } from '@src/utils/data'
+import { ExampleViewerDurationProps } from '@src/components/ExampleViewer/index'
+
+export const title = 'Narrow Domain Area Chart'
+export const subTitle = 'Generated Data'
+export const component = (props: ExampleViewerDurationProps): React.ReactNode => {
+  const tooltipRef = useRef(null)
+  const accessors = [
+    (d: XYDataRecord) => d.y,
+    (d: XYDataRecord) => d.y1,
+    (d: XYDataRecord) => d.y2,
+  ]
+
+  return (<>
+    <VisXYContainer<XYDataRecord> data={generateXYDataRecords(15)} margin={{ top: 5, left: 5 }} xDomain={[-0.2, 0.3]} scaleByDomain={true}>
+      <VisArea x={d => d.x} y={accessors} duration={props.duration}/>
+      <VisAxis type='x' numTicks={3} tickFormat={(x: number) => `${x}ms`} duration={props.duration}/>
+      <VisAxis type='y' tickFormat={(y: number) => `${y}bps`} duration={props.duration}/>
+    </VisXYContainer>
+    <VisXYContainer<XYDataRecord> data={generateXYDataRecords(15)} margin={{ top: 5, left: 5 }} xDomain={[1.5, 2.3]} scaleByDomain={true}>
+      <VisLine x={d => d.x} y={accessors} duration={props.duration}/>
+      <VisAxis type='x' numTicks={3} tickFormat={(x: number) => `${x}ms`} duration={props.duration}/>
+      <VisAxis type='y' tickFormat={(y: number) => `${y}bps`} duration={props.duration}/>
+    </VisXYContainer>
+  </>
+  )
+}

--- a/packages/ts/src/components/area/index.ts
+++ b/packages/ts/src/components/area/index.ts
@@ -136,7 +136,8 @@ export class Area<Datum> extends XYComponentCore<Datum, AreaConfigInterface<Datu
     const { config, datamodel } = this
     const yAccessors = (isArray(config.y) ? config.y : [config.y]) as NumericAccessor<Datum>[]
 
-    const data = scaleByVisibleData ? filterDataByRange(datamodel.data, this.xScale.domain() as [number, number], config.x) : datamodel.data
+    const xDomain = this.xScale.domain() as [number, number]
+    const data = scaleByVisibleData ? filterDataByRange(datamodel.data, xDomain, config.x, true) : datamodel.data
     return getStackedExtent(data, config.baseline, ...yAccessors)
   }
 

--- a/packages/ts/src/core/xy-component/index.ts
+++ b/packages/ts/src/core/xy-component/index.ts
@@ -81,10 +81,12 @@ export class XYComponentCore<
     return getExtent(datamodel.data, config.x)
   }
 
+  /** Some components override this method to provide custom data extent calculation */
   getYDataExtent (scaleByVisibleData: boolean): number[] {
     const { config, datamodel } = this
 
-    const data = scaleByVisibleData ? filterDataByRange(datamodel.data, this.xScale.domain() as [number, number], config.x) : datamodel.data
+    const xDomain = this.xScale.domain() as [number, number]
+    const data = scaleByVisibleData ? filterDataByRange(datamodel.data, xDomain, config.x, true) : datamodel.data
     const yAccessors = (isArray(config.y) ? config.y : [config.y]) as NumericAccessor<Datum>[]
     return getExtent(data, ...yAccessors)
   }

--- a/packages/ts/src/types/data.ts
+++ b/packages/ts/src/types/data.ts
@@ -3,3 +3,8 @@ export type GenericDataRecord = Record<string, unknown>
 
 /** Extension of a numbers array that carries additional information required for plotting stacked data */
 export type StackValuesRecord = Array<[number, number]> & { isMostlyNegative: boolean }
+
+export enum FindNearestDirection {
+  Left = 'left',
+  Right = 'right',
+}

--- a/packages/ts/src/utils/data.ts
+++ b/packages/ts/src/utils/data.ts
@@ -1,9 +1,9 @@
-import { max, min, mean, bisector } from 'd3-array'
+import { max, min, mean, bisectLeft, bisectRight } from 'd3-array'
 import { throttle as _throttle } from 'throttle-debounce'
 
 // Types
 import { NumericAccessor, StringAccessor, BooleanAccessor, ColorAccessor, GenericAccessor } from 'types/accessor'
-import { StackValuesRecord } from 'types/data'
+import { FindNearestDirection, StackValuesRecord } from 'types/data'
 
 export const isNumber = <T>(a: T): a is T extends number ? T : never => typeof a === 'number'
 // eslint-disable-next-line @typescript-eslint/ban-types
@@ -308,23 +308,67 @@ export function getExtent<Datum> (data: Datum[], ...acs: NumericAccessor<Datum>[
   return [getMin(data, ...acs), getMax(data, ...acs)]
 }
 
-export function getNearest<Datum> (data: Datum[], value: number, accessor: NumericAccessor<Datum>): Datum {
+export function getNearest<Datum> (
+  data: Datum[],
+  value: number,
+  accessor: NumericAccessor<Datum>,
+  direction: FindNearestDirection
+): Datum {
   if (data.length <= 1) return data[0]
 
-  const values = data.map((d, i) => getNumber(d, accessor, i))
-  values.sort((a, b) => a - b)
+  const dataWithIndex = data.map((d, i) => ([d, i])) as [Datum, number][]
+  const dataWithIndexSorted = dataWithIndex
+    .sort(([a, i], [b, j]) => getNumber(a, accessor, i) - getNumber(b, accessor, j))
+  const values = dataWithIndexSorted.map(([d, i]) => getNumber(d, accessor, i))
 
-  const xBisector = bisector(d => d).left
-  const index = xBisector(values, value, 1, data.length - 1)
-  return value - values[index - 1] > values[index] - value ? data[index] : data[index - 1]
+  const index = direction === FindNearestDirection.Left
+    ? bisectRight(values, value, 1, data.length - 1)
+    : bisectLeft(values, value, 1, data.length - 1)
+
+  if (direction === FindNearestDirection.Left) {
+    return dataWithIndexSorted[index - 1][0]
+  } else if (direction === FindNearestDirection.Right) {
+    return dataWithIndexSorted[index][0]
+  }
+
+  return value - values[index - 1] > values[index] - value ? dataWithIndexSorted[index][0] : dataWithIndexSorted[index - 1][0]
 }
 
-export function filterDataByRange<Datum> (data: Datum[], range: [number, number], accessor: NumericAccessor<Datum>): Datum[] {
+export function filterDataByRange<Datum> (
+  data: Datum[],
+  range: [number, number],
+  accessor: NumericAccessor<Datum>,
+  includeNeighbors = false
+): Datum[] {
+  if (!accessor) return []
+
   const filteredData = data.filter((d, i) => {
     const value = getNumber(d, accessor, i)
     return (value >= range[0]) && (value <= range[1])
   })
 
+  if (includeNeighbors) {
+    // If `filteredData` is empty and `includeNeighbors` is true, try to find nearest points
+    if (filteredData.length === 0) {
+      const nearestLeft = getNearest(data, range[0], accessor, FindNearestDirection.Left)
+      const nearestRight = getNearest(data, range[1], accessor, FindNearestDirection.Right)
+      return [nearestLeft, nearestRight].filter(Boolean)
+    }
+
+    // Find indices of first and last filtered points in original data
+    const firstFilteredItem = filteredData[0]
+    const lastFilteredItem = filteredData[filteredData.length - 1]
+
+    const firstFilteredIndex = data.findIndex((d: Datum) => d === firstFilteredItem)
+    const lastFilteredIndex = data.findIndex((d: Datum) => d === lastFilteredItem)
+
+    // Include neighbors (if they exist)
+    const startIndex = Math.max(0, firstFilteredIndex - 1)
+    const endIndex = Math.min(data.length - 1, lastFilteredIndex + 1)
+
+    // Return data from startIndex to endIndex (inclusive)
+    return data.slice(startIndex, endIndex + 1)
+  }
   return filteredData
 }
 


### PR DESCRIPTION
There could be situations when there are no data points, or only a single data point remains after `filterDataByRange` when calculating the domain. This was causing XY charts to go off-screen because the domain was calculated improperly.

This change addresses the issue by including neighboring data points in the filtered results.

Ref https://github.com/ExaForce/operations/issues/29673