### PR TITLE
Component | Axis: Fix for tick labels overlapping and wrapping

### DIFF
--- a/packages/dev/src/examples/xy-components/axis/axis-tick-label-overlap/index.tsx
+++ b/packages/dev/src/examples/xy-components/axis/axis-tick-label-overlap/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import { VisXYContainer, VisAxis } from '@unovis/react'
 import { ExampleViewerDurationProps } from '@src/components/ExampleViewer/index'
 import { Scale } from '@unovis/ts'
@@ -6,17 +6,36 @@ import { Scale } from '@unovis/ts'
 export const title = 'Axis Tick Label Overlap'
 export const subTitle = 'Resolving overlapping labels'
 export const component = (props: ExampleViewerDurationProps): React.ReactNode => {
+  // Define different domain configurations to cycle through
+  const domainConfigs: [number, number][][] = [
+    [[0, 1000], [0, 10000000], [0, 10000000], [0, Date.now()]],
+    [[0, 5000], [0, 50000000], [0, 50000000], [Date.now() - 86400000, Date.now()]],
+    [[0, 500], [0, 1000000], [0, 1000000], [Date.now() - 604800000, Date.now()]],
+    [[0, 10000], [0, 100000000], [0, 100000000], [Date.now() - 2592000000, Date.now()]],
+  ]
+
+  const [currentConfigIndex, setCurrentConfigIndex] = useState(0)
+  const currentConfig = domainConfigs[currentConfigIndex]
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCurrentConfigIndex((prevIndex) => (prevIndex + 1) % domainConfigs.length)
+    }, 3000)
+
+    return () => clearInterval(interval)
+  }, [domainConfigs.length])
+
   return (<>
-    <VisXYContainer xDomain={[0, 1000]} height={75}>
+    <VisXYContainer xDomain={currentConfig[0]} height={75}>
       <VisAxis type='x' numTicks={25} duration={props.duration} tickTextHideOverlapping={true}/>
     </VisXYContainer>
-    <VisXYContainer xDomain={[0, 10000000]} height={75}>
+    <VisXYContainer xDomain={currentConfig[1]} height={75}>
       <VisAxis type='x' numTicks={25} duration={props.duration} tickTextHideOverlapping={true}/>
     </VisXYContainer>
-    <VisXYContainer xDomain={[0, 10000000]} height={75}>
+    <VisXYContainer xDomain={currentConfig[2]} height={75}>
       <VisAxis type='x' numTicks={25} duration={props.duration} tickTextHideOverlapping={true} tickTextAngle={15}/>
     </VisXYContainer>
-    <VisXYContainer xDomain={[0, Date.now()]} height={125} xScale={Scale.scaleTime()}>
+    <VisXYContainer xDomain={currentConfig[3]} height={125} xScale={Scale.scaleTime()}>
       <VisAxis type='x' numTicks={7} duration={props.duration} tickTextHideOverlapping={true}/>
     </VisXYContainer>
   </>)

--- a/packages/ts/src/components/axis/index.ts
+++ b/packages/ts/src/components/axis/index.ts
@@ -238,7 +238,12 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
     // Interrupting all active transitions first to prevent them from being stuck.
     // Somehow we see it happening in Angular apps.
     selection.selectAll('*').interrupt()
-    smartTransition(selection, duration).call(axisGen)
+    const transition = smartTransition(selection, duration).call(axisGen)
+
+    // Resolving tick label overlap after the animation is over
+    transition.on('end', () => {
+      this._resolveTickLabelOverlap(selection)
+    })
 
     const ticks = selection.selectAll<SVGGElement, number | Date>('g.tick')
 

--- a/packages/ts/src/components/axis/index.ts
+++ b/packages/ts/src/components/axis/index.ts
@@ -232,7 +232,7 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
         : this._shouldRenderMinMaxTicksOnly()
           ? axisScale.domain()
           : axisScale.ticks(this._getNumTicks())
-
+    const tickCount = tickValues.length
     axisGen.tickValues(tickValues)
 
     // Interrupting all active transitions first to prevent them from being stuck.
@@ -266,7 +266,7 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
     tickText.each((value: number | Date, i: number, elements: ArrayLike<SVGTextElement>) => {
       let text = config.tickFormat?.(value, i, tickValues) ?? `${value}`
       const textElement = elements[i] as SVGTextElement
-      const textMaxWidth = config.tickTextWidth || (config.type === AxisType.X ? this._containerWidth / (ticks.size() + 1) : this._containerWidth / 5)
+      const textMaxWidth = config.tickTextWidth || (config.type === AxisType.X ? this._containerWidth / (tickCount + 1) : this._containerWidth / 5)
       const styleDeclaration = getComputedStyle(textElement)
       const fontSize = Number.parseFloat(styleDeclaration.fontSize)
       const fontFamily = styleDeclaration.fontFamily

--- a/packages/ts/src/components/axis/index.ts
+++ b/packages/ts/src/components/axis/index.ts
@@ -259,6 +259,10 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
       .classed(s.tickLabelHideable, Boolean(config.tickTextHideOverlapping))
       .style('fill', config.tickTextColor) as Selection<SVGTextElement, number, SVGGElement, unknown> | Selection<SVGTextElement, Date, SVGGElement, unknown>
 
+    // Marking exiting elements
+    selection.selectAll<SVGTextElement, number | Date>('g.tick > text')
+      .filter(tickValue => !tickValues.some((t: number | Date) => isEqual(tickValue, t)))
+      .classed(s.tickTextExiting, true)
 
     // We interrupt the transition on tick's <text> to make it 'wrappable'
     tickText.nodes().forEach(node => interrupt(node))
@@ -301,7 +305,7 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
 
   private _resolveTickLabelOverlap (selection = this.axisGroup): void {
     const { config } = this
-    const tickTextSelection = selection.selectAll<SVGTextElement, number | Date>('g.tick > text')
+    const tickTextSelection = selection.selectAll<SVGTextElement, number | Date>(`g.tick > text:not(.${s.tickTextExiting})`)
 
     if (!config.tickTextHideOverlapping) {
       tickTextSelection.style('opacity', null)

--- a/packages/ts/src/components/axis/style.ts
+++ b/packages/ts/src/components/axis/style.ts
@@ -106,6 +106,10 @@ export const tick = css`
   }
 `
 
+export const tickTextExiting = css`
+  label: tick-text-exiting;
+`
+
 export const label = css`
   label: label;
   fill: var(--vis-axis-label-color);


### PR DESCRIPTION
The `tickTextHideOverlapping` and text wrapping features were not working correctly after transitions. This PR fixes it

### Before
https://github.com/user-attachments/assets/13d85f74-5dd5-41de-a6cf-62c230bca759

### After
https://github.com/user-attachments/assets/9686213b-d3be-43fa-92a9-0d70e2f47150

