### PR TITLE
Component | Crosshair: Configurable `circleRadius`

### DIFF
--- a/packages/ts/src/components/crosshair/config.ts
+++ b/packages/ts/src/components/crosshair/config.ts
@@ -19,6 +19,8 @@ export interface CrosshairConfigInterface<Datum> extends WithOptional<XYComponen
   strokeColor?: ColorAccessor<Datum>;
   /** Optional stroke width for crosshair circles. Default: `undefined` */
   strokeWidth?: NumericAccessor<Datum>;
+  /** Radius of crosshair circles in pixels. Default: `3` */
+  circleRadius?: number;
   /** Separate array of accessors for stacked components (eg StackedBar, Area). Default: `undefined` */
   yStacked?: NumericAccessor<Datum>[];
   /** Baseline accessor function for stacked values, useful with stacked areas. Default: `null` */
@@ -78,6 +80,7 @@ export const CrosshairDefaultConfig: CrosshairConfigInterface<unknown> = {
   color: undefined,
   strokeColor: undefined,
   strokeWidth: undefined,
+  circleRadius: 4,
   onCrosshairMove: undefined,
   forceShowAt: undefined,
   skipRangeCheck: false,

--- a/packages/ts/src/components/crosshair/index.ts
+++ b/packages/ts/src/components/crosshair/index.ts
@@ -13,6 +13,7 @@ import { getColor } from 'utils/color'
 // Types
 import { Position } from 'types/position'
 import { FindNearestDirection } from 'types/data'
+import { Spacing } from 'types/spacing'
 
 // Local Types
 import { CrosshairAccessors, CrosshairCircle } from './types'
@@ -86,6 +87,15 @@ export class Crosshair<Datum> extends XYComponentCore<Datum, CrosshairConfigInte
     this.g.style('opacity', 0)
     this.line = this.g.append('line')
       .attr('class', s.line)
+  }
+
+  get bleed (): Spacing {
+    const { config: { circleRadius } } = this
+
+    // We leave the bottom bleed empty because usually the crosshair is used along with the X axis,
+    // so we don't need extra space at the bottom. For inverted charts, the users will need to specify
+    // the container margins themselves to avoid the crosshair circles from being cut off.
+    return { top: circleRadius, left: circleRadius, right: circleRadius }
   }
 
   setContainer (containerSvg: Selection<SVGSVGElement, unknown, SVGSVGElement, unknown>): void {
@@ -207,7 +217,7 @@ export class Crosshair<Datum> extends XYComponentCore<Datum, CrosshairConfigInte
     smartTransition(circlesEnter.merge(circles), duration, easeLinear)
       .attr('cx', xClamped)
       .attr('cy', d => d.y)
-      .attr('r', 4)
+      .attr('r', config.circleRadius)
       .style('opacity', d => d.opacity)
       .style('fill', d => d.color)
       .style('stroke', d => d.strokeColor)

--- a/packages/website/docs/auxiliary/Crosshair.mdx
+++ b/packages/website/docs/auxiliary/Crosshair.mdx
@@ -52,6 +52,10 @@ Provide a `string` or color accessor function to the `color` attribute to custom
 Provide values or accessor functions to the `strokeColor` and `strokeWidth` attributes to customize the crosshair's circle stroke color and width:
 <XYWrapper {...crosshairProps()} color='none' strokeColor={(d, i) => ['red', 'green', 'blue'][i]} strokeWidth={(d, i) => [1, 2, 3][i]} showContext="minimal"/>
 
+## Circle Radius
+Use the `circleRadius` attribute to set the radius of the crosshair circles in pixels. Default value is `4`.
+<XYWrapperWithInput {...crosshairProps()} property="circleRadius" defaultValue={4} inputType="range" inputProps={{ min: 0, max: 8 }} />
+
 ## Adding a Tooltip
 You can render text content for your _Crosshair_ component by providing it with a `template` property and a _Tooltip_ component within the same container.
 


### PR DESCRIPTION
https://github.com/f5/unovis/pull/760

Make circle radius configurable

```ts
  /** Radius of crosshair circles in pixels. Default: `3` */
  circleRadius?: number;
```

<img width="1498" height="502" alt="image" src="https://github.com/user-attachments/assets/acc02f27-2bbd-4cc0-b339-928c062a9202" />
