### PR TITLE
Component | Graph: Don't run `_fit` if component is destroyed

### DIFF
--- a/packages/ts/src/components/graph/index.ts
+++ b/packages/ts/src/components/graph/index.ts
@@ -481,6 +481,7 @@ export class Graph<
   }
 
   private _fit (duration = 0, nodeIds?: (string | number)[], alignment = this.config.fitViewAlign): void {
+    if (this.isDestroyed()) return
     const { datamodel, config: { nodeSize } } = this
     const nodes = nodeIds?.length ? datamodel.nodes.filter(n => nodeIds.includes(n.id)) : datamodel.nodes
 


### PR DESCRIPTION
https://github.com/f5/unovis/pull/793

Sometimes `_fit` can be triggered when component is already destroyed with throws d3-zoom errors
