### PR TITLE
Component | StackedBar: Remove elements from DOM when transition was interrupted

### DIFF
--- a/packages/ts/src/components/stacked-bar/index.ts
+++ b/packages/ts/src/components/stacked-bar/index.ts
@@ -115,6 +115,9 @@ export class StackedBar<Datum> extends XYComponentCore<Datum, StackedBarConfigIn
     smartTransition(barGroupExit, duration)
       .style('opacity', 0)
       .remove()
+      // `transition.remove()` only fires on `end`; if the transition is interrupted by a re-render,
+      // the node would linger in the DOM with opacity < 1 and could be picked up by the next data join.
+      .on('interrupt', function () { this.remove() })
 
     // Animate bars from exiting groups going down
     smartTransition(barGroupExit.selectAll(`.${s.bar}`), duration)
@@ -171,6 +174,9 @@ export class StackedBar<Datum> extends XYComponentCore<Datum, StackedBarConfigIn
     smartTransition(bars.exit(), duration)
       .style('opacity', 0)
       .remove()
+      // `transition.remove()` only fires on `end`; if the transition is interrupted by a re-render,
+      // the node would linger in the DOM with opacity < 1 and could be picked up by the next data join.
+      .on('interrupt', function () { this.remove() })
   }
 
   _getBarWidth (): number {


### PR DESCRIPTION
https://github.com/f5/unovis/pull/791

Currently when a transition gets interrupted, exiting bars remain in the DOM with opacity. In the next render, D3 reuses these bars but the opacity value remains which visually looks like they're invisible or half-visible:

<img width="634" height="217" alt="image" src="https://github.com/user-attachments/assets/6b9de734-5902-4a33-8a8b-d3f5147e7938" />

This PR fixes the problem by removing the existing bars if a transition has been interrupted.