### PR TITLE
React | XYContainer: Protect from `undefined` components

### DIFF
--- a/packages/react/src/containers/xy-container/index.tsx
+++ b/packages/react/src/containers/xy-container/index.tsx
@@ -25,7 +25,8 @@ export function VisXYContainerFC<Datum> (props: PropsWithChildren<VisXYContainer
   const getConfig = (): XYContainerConfigInterface<Datum> => ({
     components: Array
       .from(container.current?.querySelectorAll<VisComponentElement<XYComponentCore<Datum>>>('vis-component') ?? [])
-      .map(c => c.__component__),
+      .map(c => c.__component__)
+      .filter(Boolean) as XYComponentCore<Datum>[],
     tooltip: container.current?.querySelector<VisComponentElement<Tooltip>>('vis-tooltip')?.__component__,
     crosshair: container.current?.querySelector<VisComponentElement<Crosshair<Datum>>>('vis-crosshair')?.__component__,
     annotations: container.current?.querySelector<VisComponentElement<Annotations>>('vis-annotations')?.__component__,


### PR DESCRIPTION
https://github.com/f5/unovis/pull/792

In rare cases when you swap a component within XYContainer, it breaks because the value in the components array turns  undefined. This small change should fix it.