### PR TITLE
Component | Crosshair: Better transitions from `null` values

### DIFF
--- a/packages/dev/src/examples/xy-components/crosshair/sparse-data/index.tsx
+++ b/packages/dev/src/examples/xy-components/crosshair/sparse-data/index.tsx
@@ -1,0 +1,52 @@
+import React, { useRef } from 'react'
+import { VisXYContainer, VisLine, VisAxis, VisTooltip, VisCrosshair } from '@unovis/react'
+
+import { randomNumberGenerator } from '@src/utils/data'
+import { ExampleViewerDurationProps } from '@src/components/ExampleViewer/index'
+
+export const title = 'Crosshair with Sparse Data'
+export const subTitle = 'Line chart with many null values'
+
+type SparseDataRecord = {
+  x: number;
+  y: number | null;
+  y1: number | null;
+  y2: number | null;
+}
+
+function generateSparseData (n: number): SparseDataRecord[] {
+  return Array(n).fill(0).map((_, i) => ({
+    x: i,
+    y: randomNumberGenerator() < 0.6 ? null : 5 + 5 * randomNumberGenerator(),
+    y1: randomNumberGenerator() < 0.5 ? null : 1 + 3 * randomNumberGenerator(),
+    y2: randomNumberGenerator() < 0.7 ? null : 2 + 2 * randomNumberGenerator(),
+  }))
+}
+
+export const component = (props: ExampleViewerDurationProps): React.ReactNode => {
+  const tooltipRef = useRef(null)
+  const data = generateSparseData(50)
+  const accessors = [
+    (d: SparseDataRecord) => d.y,
+    (d: SparseDataRecord) => d.y1,
+    (d: SparseDataRecord) => d.y2,
+  ]
+
+  const template = (d: SparseDataRecord, x: number | Date): string => {
+    const rows = accessors.map((accessor, i) => {
+      const v = accessor(d)
+      return `<div>y${i || ''}: ${v == null ? '—' : v.toFixed(2)}</div>`
+    }).join('')
+    return `<div style="font-size: 12px;"><strong>x: ${x}</strong>${rows}</div>`
+  }
+
+  return (
+    <VisXYContainer<SparseDataRecord> data={data} margin={{ top: 5, left: 5 }} height={400} yDomain={[0, undefined]}>
+      <VisLine x={d => d.x} y={accessors} duration={props.duration}/>
+      <VisAxis type='x' duration={props.duration}/>
+      <VisAxis type='y' duration={props.duration}/>
+      <VisCrosshair<SparseDataRecord> template={template}/>
+      <VisTooltip ref={tooltipRef} container={document.body}/>
+    </VisXYContainer>
+  )
+}

--- a/packages/ts/src/components/crosshair/index.ts
+++ b/packages/ts/src/components/crosshair/index.ts
@@ -224,7 +224,11 @@ export class Crosshair<Datum> extends XYComponentCore<Datum, CrosshairConfigInte
       .style('stroke', d => d.strokeColor)
       .style('stroke-width', d => d.strokeWidth)
 
-    circles.exit().remove()
+    smartTransition(circles.exit(), duration, easeLinear)
+      .attr('r', 0)
+      .style('opacity', 0)
+      .remove()
+      .on('interrupt', function () { this.remove() })
   }
 
   hide (sourceEvent?: MouseEvent | WheelEvent): void {
@@ -308,6 +312,7 @@ export class Crosshair<Datum> extends XYComponentCore<Datum, CrosshairConfigInte
       const baselineValue = getNumber(datum, this.accessors.baseline, datumIndex) || 0
       const stackedValues: CrosshairCircle[] = getStackedValues(datum, datumIndex, ...yStackedAccessors)
         .map((value, index) => ({
+          id: `stacked-${index}`,
           y: this.yScale(value + baselineValue),
           opacity: isNumber(getNumber(datum, yStackedAccessors[index], index)) ? 1 : 0,
           color: getColor(datum, config.color, index),
@@ -319,6 +324,7 @@ export class Crosshair<Datum> extends XYComponentCore<Datum, CrosshairConfigInte
         .map((a, index) => {
           const value = getNumber(datum, a, datumIndex)
           return {
+            id: `regular-${index}`,
             y: this.yScale(value),
             opacity: isNumber(value) ? 1 : 0,
             color: getColor(datum, config.color, stackedValues.length + index),
@@ -327,7 +333,7 @@ export class Crosshair<Datum> extends XYComponentCore<Datum, CrosshairConfigInte
           }
         })
 
-      return stackedValues.concat(regularValues)
+      return stackedValues.concat(regularValues).filter(d => isNumber(d.y))
     }
 
     return []


### PR DESCRIPTION
https://github.com/f5/unovis/pull/815

Currently when crosshair circle transitions from `null` to a value it looks like it drops from the top. When the data is sparse it might look a bit annoying. This small changes fixes that.

### Before

https://github.com/user-attachments/assets/bc0015ea-7828-497c-8586-84f859dcf27a



### After


https://github.com/user-attachments/assets/1fa24294-e0ca-40aa-9c4a-9ac75c72e478

