### PR TITLE
Component | Sankey: Fix label overlap

### DIFF
--- a/packages/ts/src/components/sankey/modules/node.ts
+++ b/packages/ts/src/components/sankey/modules/node.ts
@@ -236,9 +236,12 @@ export function renderNodeLabels<N extends SankeyInputNode, L extends SankeyInpu
     }
   }
 
-  // Hide intersecting labels
+  // Hide intersecting labels.
+  // Also clear any hover-forced visibility.
   for (const b of labelGroupBBoxes) {
-    b.selection.classed(s.hidden, b.hidden)
+    b.selection
+      .classed(s.hidden, b.hidden)
+      .classed(s.forceShow, false)
   }
 }
 


### PR DESCRIPTION
https://github.com/f5/unovis/pull/853

The problem is related to stuck hover state, see reproduction:

https://github.com/user-attachments/assets/be2f1c5c-2fee-49a7-b3d1-eb67156bf891

and fix:

https://github.com/user-attachments/assets/17d133ca-6e7b-4a64-9829-44719d3e8b97

