### PR TITLE
Fix breaking changes from the color function API

### DIFF
--- a/packages/angular/src/containers/single-container/single-container.component.ts
+++ b/packages/angular/src/containers/single-container/single-container.component.ts
@@ -1,7 +1,7 @@
 import { Component, ViewChild, ElementRef, AfterViewInit, Input, OnDestroy, SimpleChanges, ContentChild } from '@angular/core'
 
 // Vis
-import { ComponentCore, SingleContainer, SingleContainerConfigInterface, Tooltip, Spacing, Annotations, Sizing } from '@unovis/ts'
+import { ColorFunction, ComponentCore, SingleContainer, SingleContainerConfigInterface, Tooltip, Spacing, Annotations, Sizing } from '@unovis/ts'
 import { VisCoreComponent } from '../../core'
 import { VisTooltipComponent } from '../../components/tooltip/tooltip.component'
 import { VisAnnotationsComponent } from '../../components/annotations/annotations.component'
@@ -45,6 +45,11 @@ export class VisSingleContainerComponent<Data = unknown, C extends ComponentCore
   /** Defines whether components should fit into the container or the container should expand to fit to the component's size.
    * Works with a limited set of components. Default: `Sizing.Fit` */
   @Input() sizing?: Sizing | string
+  /** A custom color function to be used for all the components within the container.
+   * Maps indices or data color keys (when `colorKeys` are provided to components) to colors.
+   * Default: `undefined`
+  */
+  @Input() colorFunction?: ColorFunction
   /** Data to be passed to the component. Default: `undefined`. */
   @Input() data?: Data
 
@@ -68,13 +73,13 @@ export class VisSingleContainerComponent<Data = unknown, C extends ComponentCore
   }
 
   getConfig (): SingleContainerConfigInterface<Data> {
-    const { width, height, duration, margin, ariaLabel, svgDefs, sizing } = this
+    const { width, height, duration, margin, ariaLabel, svgDefs, sizing, colorFunction } = this
 
     const component = this.visComponent?.component as C
     const tooltip = this.tooltipComponent?.component as Tooltip
     const annotations = this.annotationsComponent?.component as Annotations
 
-    return { width, height, duration, margin, component, tooltip, ariaLabel, annotations, svgDefs, sizing }
+    return { width, height, duration, margin, component, tooltip, ariaLabel, annotations, svgDefs, sizing, colorFunction }
   }
 
   ngOnDestroy (): void {

--- a/packages/angular/src/containers/xy-container/xy-container.component.ts
+++ b/packages/angular/src/containers/xy-container/xy-container.component.ts
@@ -13,7 +13,18 @@ import {
 } from '@angular/core'
 
 // Vis
-import { Annotations, Axis, ContinuousScale, Crosshair, Direction, Spacing, Tooltip, XYContainer, XYContainerConfigInterface } from '@unovis/ts'
+import {
+  Annotations,
+  Axis,
+  ColorFunction,
+  ContinuousScale,
+  Crosshair,
+  Direction,
+  Spacing,
+  Tooltip,
+  XYContainer,
+  XYContainerConfigInterface,
+} from '@unovis/ts'
 import { VisXYComponent } from '../../core'
 import { VisTooltipComponent } from '../../components/tooltip/tooltip.component'
 import { VisAnnotationsComponent } from '../../components/annotations/annotations.component'
@@ -113,6 +124,12 @@ export class VisXYContainerComponent<Datum> implements AfterViewInit, AfterConte
   */
   @Input() ariaLabel?: string | null | undefined
 
+  /** A custom color function to be used for all the components within the container.
+   * Maps indices or data color keys (when `colorKeys` are provided to components) to colors.
+   * Default: `undefined`
+  */
+  @Input() colorFunction?: ColorFunction
+
   /** Data to be passed to all child components. But if `data` is `undefined` it'll to be passed allowing components to
    * have their individual data. Default: `undefined` */
   @Input() data?: Datum[] | undefined = undefined
@@ -150,7 +167,7 @@ export class VisXYContainerComponent<Datum> implements AfterViewInit, AfterConte
       duration, margin, padding, scaleByDomain, autoMargin, width, height,
       xScale, xDomain, xDomainMinConstraint, xDomainMaxConstraint, xRange,
       yScale, yDomain, yDomainMinConstraint, yDomainMaxConstraint, yRange,
-      yDirection, ariaLabel,
+      yDirection, ariaLabel, colorFunction,
     } = this
     const visComponents = this.visComponents.toArray().map(d => d.component)
 
@@ -188,6 +205,7 @@ export class VisXYContainerComponent<Datum> implements AfterViewInit, AfterConte
       yRange,
       yDirection,
       ariaLabel,
+      colorFunction,
     }
   }
 

--- a/packages/angular/src/html-components/bullet-legend/bullet-legend.component.ts
+++ b/packages/angular/src/html-components/bullet-legend/bullet-legend.component.ts
@@ -62,7 +62,7 @@ export class VisBulletLegendComponent implements BulletLegendConfigInterface, Af
   @Input() orientation?: BulletLegendOrientation | string
 
   /** Color function. Default: `undefined` */
-  @Input() color?: ColorFunction
+  @Input() colorFunction?: ColorFunction
 
   component: BulletLegend | undefined
 
@@ -75,8 +75,8 @@ export class VisBulletLegendComponent implements BulletLegendConfigInterface, Af
   }
 
   private getConfig (): BulletLegendConfigInterface {
-    const { items, labelClassName, onLegendItemClick, labelFontSize, labelMaxWidth, bulletSize, bulletSpacing, bulletShape, orientation, color } = this
-    const config = { items, labelClassName, onLegendItemClick, labelFontSize, labelMaxWidth, bulletSize, bulletSpacing, bulletShape, orientation, color }
+    const { items, labelClassName, onLegendItemClick, labelFontSize, labelMaxWidth, bulletSize, bulletSpacing, bulletShape, orientation, colorFunction } = this
+    const config = { items, labelClassName, onLegendItemClick, labelFontSize, labelMaxWidth, bulletSize, bulletSpacing, bulletShape, orientation, colorFunction }
     const keys = Object.keys(config) as (keyof BulletLegendConfigInterface)[]
     keys.forEach(key => { if (config[key] === undefined) delete config[key] })
 

--- a/packages/dev/src/examples/color/color-management/color-sync/index.tsx
+++ b/packages/dev/src/examples/color/color-management/color-sync/index.tsx
@@ -53,21 +53,21 @@ export const component = (props: ExampleViewerDurationProps): React.ReactNode =>
       <div style={blockStyle}>
         <p>This block of charts uses a color function defined with <code>scaleOrdinal</code> from D3</p>
         <VisBulletLegend
-          color={leftBlockColorScale}
+          colorFunction={leftBlockColorScale}
           items={leftBlockChartKeys.map(key => ({ name: key, colorKey: key }))}
         />
-        <VisXYContainer<Datum> data={data} color={leftBlockColorScale}>
+        <VisXYContainer<Datum> data={data} colorFunction={leftBlockColorScale}>
           <VisLine x={d => d.x} y={accessorsLeftBlockCharts} colorKeys={leftBlockChartKeys}/>
           <VisGroupedBar x={d => d.x} y={accessorsLeftBlockCharts} colorKeys={leftBlockChartKeys} barPadding={0.3}/>
           <VisAxis type='x'/>
           <VisCrosshair template={(d: Datum) => `x: ${d.x}`} />
         </VisXYContainer>
-        <VisXYContainer<Datum> data={data.slice(0, 10)} color={leftBlockColorScale}>
+        <VisXYContainer<Datum> data={data.slice(0, 10)} colorFunction={leftBlockColorScale}>
           <VisGroupedBar x={d => d.x} y={accessorsLeftBlockCharts} colorKeys={leftBlockChartKeys} barPadding={0.1}/>
           <VisAxis type='x'/>
           <VisCrosshair template={(d: Datum) => `x: ${d.x}`} />
         </VisXYContainer>
-        <VisXYContainer<Datum> data={data} color={leftBlockColorScale}>
+        <VisXYContainer<Datum> data={data} colorFunction={leftBlockColorScale}>
           <VisArea x={d => d.x} y={accessorsLeftBlockCharts} colorKeys={leftBlockChartKeys}/>
           <VisAxis type='x'/>
           <VisCrosshair template={(d: Datum) => `x: ${d.x}`} />
@@ -76,15 +76,15 @@ export const component = (props: ExampleViewerDurationProps): React.ReactNode =>
       <div style={blockStyle}>
         <p>This block defines a custom color function that assigns the colors using a color map</p>
         <VisBulletLegend
-          color={rightBlockColorFunction}
+          colorFunction={rightBlockColorFunction}
           items={rightBlockChartKeys.map(key => ({ name: key, colorKey: key }))}
         />
-        <VisXYContainer<Datum> data={data} color={rightBlockColorFunction}>
+        <VisXYContainer<Datum> data={data} colorFunction={rightBlockColorFunction}>
           <VisStackedBar x={d => d.x} y={accessorsRightBlockCharts} colorKeys={rightBlockChartKeys} barPadding={0.05}/>
           <VisAxis type='x' />
           <VisCrosshair template={(d: Datum) => `x: ${d.x}`} />
         </VisXYContainer>
-        <VisXYContainer<Datum> data={data.slice(0, 15)} color={rightBlockColorFunction}>
+        <VisXYContainer<Datum> data={data.slice(0, 15)} colorFunction={rightBlockColorFunction}>
           <VisScatter x={d => d.x} y={accessorsRightBlockCharts} colorKeys={rightBlockChartKeys}/>
           <VisAxis type='x' />
           <VisCrosshair template={(d: Datum) => `x: ${d.x}`} />

--- a/packages/ts/src/components/bullet-legend/config.ts
+++ b/packages/ts/src/components/bullet-legend/config.ts
@@ -38,7 +38,7 @@ export interface BulletLegendConfigInterface {
    * without creating additional `div` element. Default: `false` */
   renderIntoProvidedDomNode?: boolean;
   /** Color function. Default: `undefined` */
-  color?: ColorFunction;
+  colorFunction?: ColorFunction;
 }
 
 export const BulletLegendDefaultConfig: BulletLegendConfigInterface = {

--- a/packages/ts/src/components/bullet-legend/index.ts
+++ b/packages/ts/src/components/bullet-legend/index.ts
@@ -82,7 +82,7 @@ export class BulletLegend {
       })
       .style('height', config.bulletSize)
       .style('box-sizing', 'content-box')
-      .call(updateBullets, this.config, this._colorAccessor, config.color)
+      .call(updateBullets, this.config, this._colorAccessor, config.colorFunction)
 
     // Labels
     legendItemsEnter.append('span')

--- a/packages/ts/src/containers/single-container/index.ts
+++ b/packages/ts/src/containers/single-container/index.ts
@@ -101,7 +101,7 @@ export class SingleContainer<Data> extends ContainerCore {
     super._preRender()
     this.component.setSize(this.width, this.height, this.containerWidth, this.containerHeight)
     this.component.setContainerMargin(config.margin)
-    this.component.setColorFunction(config.color)
+    this.component.setColorFunction(config.colorFunction)
     config.annotations?.setSize(this.width, this.height, this.containerWidth, this.containerHeight)
     config.annotations?.setContainerMargin(config.margin)
   }

--- a/packages/ts/src/containers/xy-container/index.ts
+++ b/packages/ts/src/containers/xy-container/index.ts
@@ -230,7 +230,7 @@ export class XYContainer<Datum> extends ContainerCore {
     for (const c of components) {
       c.setSize(this.width, this.height, this.containerWidth, this.containerHeight)
       c.setContainerMargin(margin)
-      c.setColorFunction(config.color)
+      c.setColorFunction(config.colorFunction)
     }
 
     // Update Scales of all the components at once to calculate required paddings and sync them

--- a/packages/ts/src/core/container/config.ts
+++ b/packages/ts/src/core/container/config.ts
@@ -36,7 +36,7 @@ export interface ContainerConfigInterface {
    * Maps indices or data color keys (when `colorKeys` are provided to components) to colors.
    * Default: `undefined`
   */
-  color?: ColorFunction;
+  colorFunction?: ColorFunction;
 }
 
 export const ContainerDefaultConfig: ContainerConfigInterface = {
@@ -62,5 +62,5 @@ export const ContainerDefaultConfig: ContainerConfigInterface = {
   svgDefs: undefined,
   ariaLabel: undefined,
 
-  color: undefined,
+  colorFunction: undefined,
 }

--- a/packages/ts/src/utils/color.ts
+++ b/packages/ts/src/utils/color.ts
@@ -22,7 +22,7 @@ export function getColor<T> (
   d: T,
   accessorOrValue: ColorAccessor<T>,
   index?: number,
-  key?: string,
+  key?: string | boolean, // Todo: Remove (key === true) in Unovis 2.0. We have is only for backward compatibility, it used to be `dontFallbackToCssVar`
   options?: {
     dontFallbackToCssVar?: boolean;
     colorFn?: ColorFunction;
@@ -42,12 +42,15 @@ export function getColor<T> (
 
   // If key is provided, return the color for the key
   const colorScale = options?.colorFn ?? UnovisColorScale
-  if (key) {
+  if (typeof key === 'string' && key) {
     return colorScale(key as string)
   }
 
+  // Todo: Remove (key === true) in Unovis 2.0. We have is only for backward compatibility.
+  const dontFallbackToCssVar = options?.dontFallbackToCssVar ?? (key === true)
+
   // If index is a number and `dontFallbackToCssVar` is `false`, return the color for the index
-  if (isNumber(index) && !options?.dontFallbackToCssVar) return colorScale(index % colors.length)
+  if (isNumber(index) && !dontFallbackToCssVar) return colorScale(index % colors.length)
 
   // If all else fails, return null
   return null

--- a/packages/website/docs/containers/Single_Container.mdx
+++ b/packages/website/docs/containers/Single_Container.mdx
@@ -150,7 +150,7 @@ To change the default palette or keep colors consistent across charts, see
 _Theming_ guide — re-ranging `UnovisColorScale` there recolors these components' default palette too.
 
 :::note
-Unlike [XY Container](XY_Container#color), the container-level `color` _function_ is consumed by XY
+Unlike [XY Container](XY_Container#color), the container-level `colorFunction` is consumed by XY
 components. Single-component visualizations such as _Donut_, _Sankey_, and _ChordDiagram_ take their color
 from the component's own `color` accessor.
 :::

--- a/packages/website/docs/containers/XY_Container.mdx
+++ b/packages/website/docs/containers/XY_Container.mdx
@@ -232,10 +232,10 @@ You can set `yDirection` to change the direction of data along the Y axis. Suppo
 <XYWrapper {...xyContainerProps()} yDirection='south' showContext='container'/>
 
 ## Color
-Use the `color` property to give every component inside the container a single _color function_ of type
+Use the `colorFunction` property to give every component inside the container a single _color function_ of type
 `(key: string | number) => string`. Each component resolves its color through this function, passing either a
 data **color key** (from the component's `colorKeys` property) or, as a fallback, the series index. Supplying
-one `color` function at the container level — and reusing it across other containers and the `BulletLegend` —
+one `colorFunction` at the container level — and reusing it across other containers and the `BulletLegend` —
 is how you keep a category's color consistent across multiple charts.
 
 ```ts
@@ -244,7 +244,7 @@ const color = Scale.scaleOrdinal().range(['#4d8cfd', '#ff6b7e', '#00c19a'])
 ```
 
 In the example below the _StackedBar_'s three series are labeled with `colorKeys`, and the container's
-`color` function maps each key to a color:
+`colorFunction` maps each key to a color:
 
 <BrowserOnly>
 {() => {
@@ -253,7 +253,7 @@ In the example below the _StackedBar_'s three series are labeled with `colorKeys
   return (
     <XYWrapper
       {...xyContainerProps('StackedBar')}
-      containerProps={{ color }}
+      containerProps={{ colorFunction: color }}
       components={[
         component('StackedBar', { y: [d => d.y, d => d.y1, d => d.y2], colorKeys: ['aws', 'azure', 'github'] }),
         { name: 'Axis', props: { type: 'x' }, key: 'xAxis' },

--- a/packages/website/docs/guides/theming.mdx
+++ b/packages/website/docs/guides/theming.mdx
@@ -263,8 +263,8 @@ There are three pieces:
 
 - **`colorKeys`** — a component property: an array of string keys, one per `y` accessor, that labels each
 series (e.g. `['aws', 'azure', 'github']`).
-- **`color`** — a _color function_ of type `(key: string | number) => string`. It is accepted by the
-**container** (where it applies to every component inside) and by **`BulletLegend`**. Given a key, it returns a color.
+- **`colorFunction`** — a function of type `(key: string | number) => string`, accepted by the **container**
+(where it applies to every component inside) and by **`BulletLegend`**. Given a key, it returns a color.
 - **`UnovisColorScale`** — the default color function, used when you don't provide your own.
 
 ### How a color is resolved
@@ -297,7 +297,7 @@ const color = (key) => colorMap[key] ?? '#cccccc'
 ```
 
 ### Putting it together
-Pass the **same** `color` function to every container and legend, and give each component a `colorKeys`
+Pass the **same** color function to every container and legend, and give each component a `colorKeys`
 array aligned with its `y` accessors:
 
 <FrameworkTabs
@@ -309,14 +309,14 @@ const keys = ['aws', 'azure', 'github']
 const y = keys.map(k => (d) => d[k])
 
 // Legend, charts, and tooltips all share the same color function and keys
-<VisBulletLegend items={keys.map(name => ({ name, colorKey: name }))} color={color} />
+<VisBulletLegend items={keys.map(name => ({ name, colorKey: name }))} colorFunction={color} />
 
-<VisXYContainer data={data} color={color}>
+<VisXYContainer data={data} colorFunction={color}>
   <VisGroupedBar x={d => d.x} y={y} colorKeys={keys} />
   <VisAxis type="x" />
 </VisXYContainer>
 
-<VisXYContainer data={data} color={color}>
+<VisXYContainer data={data} colorFunction={color}>
   <VisArea x={d => d.x} y={y} colorKeys={keys} />
   <VisAxis type="x" />
 </VisXYContainer>`}
@@ -329,14 +329,14 @@ keys = ['aws', 'azure', 'github']
 x = (d) => d.x
 y = this.keys.map(k => (d) => d[k])
 items = this.keys.map(name => ({ name, colorKey: name }))`,
-    html: `<vis-bullet-legend [items]="items" [color]="color"></vis-bullet-legend>
+    html: `<vis-bullet-legend [items]="items" [colorFunction]="color"></vis-bullet-legend>
 
-<vis-xy-container [data]="data" [color]="color">
+<vis-xy-container [data]="data" [colorFunction]="color">
   <vis-grouped-bar [x]="x" [y]="y" [colorKeys]="keys"></vis-grouped-bar>
   <vis-axis type="x"></vis-axis>
 </vis-xy-container>
 
-<vis-xy-container [data]="data" [color]="color">
+<vis-xy-container [data]="data" [colorFunction]="color">
   <vis-area [x]="x" [y]="y" [colorKeys]="keys"></vis-area>
   <vis-axis type="x"></vis-axis>
 </vis-xy-container>`,
@@ -352,14 +352,14 @@ items = this.keys.map(name => ({ name, colorKey: name }))`,
   const items = keys.map(name => ({ name, colorKey: name }))
 </script>
 
-<VisBulletLegend {items} {color} />
+<VisBulletLegend {items} colorFunction={color} />
 
-<VisXYContainer {data} {color}>
+<VisXYContainer {data} colorFunction={color}>
   <VisGroupedBar {x} {y} colorKeys={keys} />
   <VisAxis type="x" />
 </VisXYContainer>
 
-<VisXYContainer {data} {color}>
+<VisXYContainer {data} colorFunction={color}>
   <VisArea {x} {y} colorKeys={keys} />
   <VisAxis type="x" />
 </VisXYContainer>`}
@@ -375,14 +375,14 @@ const items = keys.map(name => ({ name, colorKey: name }))
 </script>
 
 <template>
-  <VisBulletLegend :items="items" :color="color" />
+  <VisBulletLegend :items="items" :colorFunction="color" />
 
-  <VisXYContainer :data="data" :color="color">
+  <VisXYContainer :data="data" :colorFunction="color">
     <VisGroupedBar :x="x" :y="y" :colorKeys="keys" />
     <VisAxis type="x" />
   </VisXYContainer>
 
-  <VisXYContainer :data="data" :color="color">
+  <VisXYContainer :data="data" :colorFunction="color">
     <VisArea :x="x" :y="y" :colorKeys="keys" />
     <VisAxis type="x" />
   </VisXYContainer>
@@ -395,14 +395,14 @@ const keys = ['aws', 'azure', 'github']
 const y = keys.map(k => (d) => d[k])
 
 // Legend, charts, and tooltips all share the same color function and keys
-<VisBulletLegend items={keys.map(name => ({ name, colorKey: name }))} color={color} />
+<VisBulletLegend items={keys.map(name => ({ name, colorKey: name }))} colorFunction={color} />
 
-<VisXYContainer data={data} color={color}>
+<VisXYContainer data={data} colorFunction={color}>
   <VisGroupedBar x={d => d.x} y={y} colorKeys={keys} />
   <VisAxis type="x" />
 </VisXYContainer>
 
-<VisXYContainer data={data} color={color}>
+<VisXYContainer data={data} colorFunction={color}>
   <VisArea x={d => d.x} y={y} colorKeys={keys} />
   <VisAxis type="x" />
 </VisXYContainer>`}
@@ -415,24 +415,24 @@ const y = keys.map(k => (d) => d[k])
 // Legend, charts, and tooltips all share the same color function and keys
 const legend = new BulletLegend(legendNode, {
   items: keys.map(name => ({ name, colorKey: name })),
-  color,
+  colorFunction: color,
 })
 
 const groupedBar = new XYContainer(node1, {
-  color,
+  colorFunction: color,
   components: [new GroupedBar({ x: d => d.x, y, colorKeys: keys })],
   xAxis: new Axis({ type: 'x' }),
 }, data)
 
 const area = new XYContainer(node2, {
-  color,
+  colorFunction: color,
   components: [new Area({ x: d => d.x, y, colorKeys: keys })],
   xAxis: new Axis({ type: 'x' }),
 }, data)`}
 />
 
 A few things to keep in mind:
-- `BulletLegend` items carry their key in `colorKey`; pass the same `color` function so the bullets match the charts.
+- `BulletLegend` items carry their key in `colorKey`; pass the same `colorFunction` so the bullets match the charts.
 - The crosshair tooltip picks up `colorKeys` from the components automatically, so its markers stay in sync too.
 - Keep `colorKeys` the same length as the `y` accessor array.
 
@@ -454,12 +454,12 @@ and the legend, bars, and area all agree on the color of every category:
   const reversed = ['github', 'azure', 'aws']
   return (
     <div>
-      <VisBulletLegend items={keys.map(name => ({ name, colorKey: name }))} color={color} />
-      <VisXYContainer data={data} color={color} height={140}>
+      <VisBulletLegend items={keys.map(name => ({ name, colorKey: name }))} colorFunction={color} />
+      <VisXYContainer data={data} colorFunction={color} height={140}>
         <VisGroupedBar x={d => d.x} y={keys.map(k => d => d[k])} colorKeys={keys} />
         <VisAxis type="x" />
       </VisXYContainer>
-      <VisXYContainer data={data} color={color} height={140}>
+      <VisXYContainer data={data} colorFunction={color} height={140}>
         <VisArea x={d => d.x} y={reversed.map(k => d => d[k])} colorKeys={reversed} opacity={0.7} />
         <VisAxis type="x" />
       </VisXYContainer>
@@ -469,7 +469,7 @@ and the legend, bars, and area all agree on the color of every category:
 </BrowserOnly>
 
 ### Overriding the default palette in code
-When you don't pass a `color` function, components fall back to **`UnovisColorScale`** — a D3 ordinal scale
+When you don't pass a color function, components fall back to **`UnovisColorScale`** — a D3 ordinal scale
 whose range is the `--vis-color*` CSS variables. You can re‑range it once at startup to change the default
 palette everywhere, without touching CSS:
 


### PR DESCRIPTION
https://github.com/f5/unovis/pull/856

This PR addresses two breaking changes introduced by the recent custom color function work, before they ship in a release.

### Rename `color` to `colorFunction`

The new custom color function config property on containers and `BulletLegend` was named `color`, which is both ambiguous (it holds a function, not a color value) and collides with the widely used `color` accessor naming on components. It is now `colorFunction`:

```ts
// Before
<VisXYContainer color={myColorScale}>
// After
<VisXYContainer colorFunction={myColorScale}>
```

Applied to `ContainerConfigInterface` (so both `SingleContainer` and `XYContainer`), `BulletLegendConfigInterface`, and the Angular wrappers — which also now actually expose the input on `VisSingleContainerComponent` and `VisXYContainerComponent`. Dev examples and website docs (`Single_Container`, `XY_Container`, theming guide) are updated to match.

### Backward compatibility for `getColor`

The `getColor` utility's fourth positional argument used to be `dontFallbackToCssVar: boolean` and was repurposed as `key: string`, silently breaking existing callers. `getColor` now accepts `string | boolean` there: a string is treated as a color key, while `true` is interpreted as the legacy `dontFallbackToCssVar` flag (unless explicitly set via `options`). Marked with TODOs to drop the boolean form in Unovis 2.0.
