### PR TITLE
Container | XY: Add `bleed` config option

### DIFF
--- a/packages/angular/src/containers/xy-container/xy-container.component.ts
+++ b/packages/angular/src/containers/xy-container/xy-container.component.ts
@@ -22,6 +22,7 @@ import {
   Direction,
   Spacing,
   Tooltip,
+  XYComponentCore,
   XYContainer,
   XYContainerConfigInterface,
 } from '@unovis/ts'
@@ -119,6 +120,15 @@ export class VisXYContainerComponent<Datum> implements AfterViewInit, AfterConte
   @Input() scaleByDomain?: boolean
   /** Enables automatic calculation of chart margins based on the size of the axes. Default: `true` */
   @Input() autoMargin?: boolean = true
+  /** Override the automatically calculated bleed — the extra space (in pixels) the components request
+   * to fully fit into the container (e.g. half of the point diameter for Scatter), which gets subtracted
+   * from the scale ranges. Accepts a `Spacing` object or a function that receives the container's
+   * components (their individual bleed values are available via the `bleed` getter) and returns one.
+   * The sides you provide replace the calculated values, the sides left `undefined` fall back to them —
+   * pass `0` explicitly to remove the bleed on a side.
+   * Useful for synchronizing the scale ranges of multiple charts, since the final bleed is provided
+   * to the `onRenderComplete` callback. Default: `undefined` */
+  @Input() bleed?: Spacing | ((components: XYComponentCore<Datum>[]) => Spacing)
 
   /** Alternative text description of the chart for accessibility purposes. It will be applied as an
    * `aria-label` attribute to the div element containing your chart. Default: `undefined`.
@@ -165,7 +175,7 @@ export class VisXYContainerComponent<Datum> implements AfterViewInit, AfterConte
 
   getConfig (): XYContainerConfigInterface<Datum> {
     const {
-      duration, margin, padding, scaleByDomain, autoMargin, width, height,
+      duration, margin, padding, scaleByDomain, autoMargin, bleed, width, height,
       xScale, xDomain, xDomainMinConstraint, xDomainMaxConstraint, xRange,
       yScale, yDomain, yDomainMinConstraint, yDomainMaxConstraint, yRange,
       yDirection, ariaLabel, colorFunction,
@@ -194,6 +204,7 @@ export class VisXYContainerComponent<Datum> implements AfterViewInit, AfterConte
       annotations,
       scaleByDomain,
       autoMargin,
+      bleed,
       xScale,
       xDomain,
       xDomainMinConstraint,

--- a/packages/dev/src/examples/xy-components/xy-container/bleed-sync/index.tsx
+++ b/packages/dev/src/examples/xy-components/xy-container/bleed-sync/index.tsx
@@ -1,0 +1,65 @@
+import React, { useCallback, useState } from 'react'
+import { Spacing } from '@unovis/ts'
+import { VisXYContainer, VisScatter, VisLine, VisArea, VisStackedBar, VisAxis } from '@unovis/react'
+import { generateXYDataRecords, XYDataRecord } from '@src/utils/data'
+import { ExampleViewerDurationProps } from '@src/components/ExampleViewer/index'
+
+export const title = 'Bleed Synchronization'
+export const subTitle = 'Sharing bleed between containers'
+
+const data = generateXYDataRecords(25)
+const xDomain: [number, number] = [1, 20]
+
+export const component = (props: ExampleViewerDurationProps): React.ReactNode => {
+  const [syncBleed, setSyncBleed] = useState(true)
+  const [scatterBleed, setScatterBleed] = useState<Spacing>()
+
+  const x = useCallback((d: XYDataRecord) => d.x, [])
+  const y = useCallback((d: XYDataRecord) => d.y, [])
+
+  // The Scatter chart needs the most horizontal space to fit its points, so we take
+  // its bleed from the `onRenderComplete` callback and pass it to the charts below
+  const onRenderComplete = useCallback((svg: SVGSVGElement, margin: Spacing, bleed: Spacing): void => {
+    setScatterBleed(prev => (prev?.left === bleed.left && prev?.right === bleed.right)
+      ? prev
+      : { left: bleed.left, right: bleed.right }
+    )
+  }, [])
+
+  // We synchronize the `left` and `right` values only, `top` and `bottom` are left
+  // undefined so that every chart falls back to its own calculated vertical bleed
+  const bleed = syncBleed ? scatterBleed : undefined
+
+  return (
+    <>
+      <label>
+        <input type='checkbox' checked={syncBleed} onChange={e => setSyncBleed(e.target.checked)}/>
+        Synchronize bleed
+      </label>
+
+      <VisXYContainer data={data} height={150} xDomain={xDomain} onRenderComplete={onRenderComplete}>
+        <VisScatter x={x} y={y} size={30} duration={props.duration}/>
+        <VisAxis type='x' duration={props.duration}/>
+        <VisAxis type='y' duration={props.duration}/>
+      </VisXYContainer>
+
+      <VisXYContainer data={data} height={150} xDomain={xDomain} bleed={bleed}>
+        <VisStackedBar x={x} y={y} duration={props.duration}/>
+        <VisAxis type='x' duration={props.duration}/>
+        <VisAxis type='y' duration={props.duration}/>
+      </VisXYContainer>
+
+      <VisXYContainer data={data} height={150} xDomain={xDomain} bleed={bleed}>
+        <VisArea x={x} y={y} duration={props.duration}/>
+        <VisAxis type='x' duration={props.duration}/>
+        <VisAxis type='y' duration={props.duration}/>
+      </VisXYContainer>
+
+      <VisXYContainer data={data} height={150} xDomain={xDomain} bleed={bleed}>
+        <VisLine x={x} y={y} duration={props.duration}/>
+        <VisAxis type='x' duration={props.duration}/>
+        <VisAxis type='y' duration={props.duration}/>
+      </VisXYContainer>
+    </>
+  )
+}

--- a/packages/ts/src/containers/xy-container/config.ts
+++ b/packages/ts/src/containers/xy-container/config.ts
@@ -92,6 +92,15 @@ export interface XYContainerConfigInterface<Datum> extends ContainerConfigInterf
   annotations?: Annotations | undefined;
   /** Extend the clip path by the specified number of pixels. Default: `2` */
   clipPathExtend?: number;
+  /** Override the automatically calculated bleed — the extra space (in pixels) the components request
+   * to fully fit into the container (e.g. half of the point diameter for Scatter), which gets subtracted
+   * from the scale ranges. Accepts a `Spacing` object or a function that receives the container's
+   * components (their individual bleed values are available via the `bleed` getter) and returns one.
+   * The sides you provide replace the calculated values, the sides left `undefined` fall back to them —
+   * pass `0` explicitly to remove the bleed on a side.
+   * Useful for synchronizing the scale ranges of multiple charts, since the final bleed is provided
+   * to the `onRenderComplete` callback. Default: `undefined` */
+  bleed?: Spacing | ((components: XYComponentCore<Datum>[]) => Spacing);
   /** Callback function to be called when the chart rendering is complete. Default: `undefined` */
   onRenderComplete?: (
     svgNode: SVGSVGElement,
@@ -132,5 +141,6 @@ export const XYContainerDefaultConfig: XYContainerConfigInterface<unknown> = {
   scaleByDomain: false,
 
   clipPathExtend: 2,
+  bleed: undefined,
 }
 

--- a/packages/ts/src/containers/xy-container/index.ts
+++ b/packages/ts/src/containers/xy-container/index.ts
@@ -20,7 +20,7 @@ import { ScaleDimension } from '@/types/scale'
 import { Direction } from '@/types/direction'
 
 // Utils
-import { clamp, clean, flatten } from '@/utils/data'
+import { clamp, clean, flatten, isFunction } from '@/utils/data'
 import { guid } from '@/utils/misc'
 
 // Config
@@ -459,13 +459,27 @@ export class XYContainer<Datum> extends ContainerCore {
   }
 
   private _getBleed<T extends XYComponentCore<Datum>> (components: T[]): Spacing {
-    return components.map(c => c.bleed).reduce((bleed, b) => {
+    // We request the components' bleed even when the configured `bleed` overrides the result,
+    // because some components prepare their internal rendering state in the `bleed` getter
+    const calculatedBleed = components.map(c => c.bleed).reduce((bleed, b) => {
       for (const key of Object.keys(bleed)) {
         const k = key as keyof Spacing
         if (bleed[k] < b[k]) bleed[k] = b[k]
       }
       return bleed
     }, { top: 0, bottom: 0, left: 0, right: 0 })
+
+    const configuredBleed = isFunction(this.config.bleed) ? this.config.bleed(components) : this.config.bleed
+    if (configuredBleed) {
+      return {
+        top: configuredBleed.top ?? calculatedBleed.top,
+        bottom: configuredBleed.bottom ?? calculatedBleed.bottom,
+        left: configuredBleed.left ?? calculatedBleed.left,
+        right: configuredBleed.right ?? calculatedBleed.right,
+      }
+    }
+
+    return calculatedBleed
   }
 
   public destroy (): void {

--- a/packages/website/docs/containers/XY_Container.mdx
+++ b/packages/website/docs/containers/XY_Container.mdx
@@ -119,6 +119,48 @@ const padding = { left: 100, right: 100 }
   <XYWrapper className='showBorder' {...xyContainerProps()} containerProps={{ height: 100, padding: { left: 100, right: 100 }}} excludeTabs/>
 </div>
 
+### Bleed
+Some components need extra space inside the container for their marks to fully fit: half of the point
+diameter for _Scatter_, half of the bar width for bar charts at the edges of the domain, and so on. This
+space is called **bleed**. Before rendering, the container asks every component how much bleed it needs,
+combines the values (taking the maximum for each side), and shrinks the scale ranges accordingly. That's
+why the first and the last points of the scatter chart below are shifted inward from the container's
+edges instead of being cut in half:
+
+<XYWrapper {...xyContainerProps('Scatter')}
+  components={[
+    component('Scatter', { size: 25 }),
+    { name: 'Axis', props: { type: 'x' }, key: 'xAxis'},
+    { name: 'Axis', props: { type: 'y' }, key: 'yAxis'},
+  ]}
+  height={125}
+  excludeTabs
+/>
+
+The container reports the bleed it used to the `onRenderComplete` callback, and you can override the
+calculated values with the `bleed` property. It accepts a <a href='#sizing'>Spacing</a> object, or a
+function that receives the container's components and returns one. The sides you provide replace the
+calculated values, the sides left `undefined` fall back to them. Here is the same chart with the
+bleed set to zero on every side — the edge points now get clipped:
+
+```ts
+const bleed = { top: 0, bottom: 0, left: 0, right: 0 }
+```
+
+<XYWrapper {...xyContainerProps('Scatter')}
+  components={[
+    component('Scatter', { size: 25 }),
+    { name: 'Axis', props: { type: 'x' }, key: 'xAxis'},
+    { name: 'Axis', props: { type: 'y' }, key: 'yAxis'},
+  ]}
+  height={125}
+  containerProps={{ bleed: { top: 0, bottom: 0, left: 0, right: 0 } }}
+  excludeTabs
+/>
+
+Overriding the bleed is mainly useful for aligning the X values of several charts placed one below
+another — see the [Bleed](/docs/guides/bleed) guide for a complete walkthrough.
+
 ### Range
 The `xRange` and `yRange` determine the screen space your chart contains. By default, an _XY Container_ will
 fit to its container. Provide `xRange` with values [`xStart`, `width`] and `yRange` with [`yStart`, `height`]

--- a/packages/website/docs/guides/bleed.mdx
+++ b/packages/website/docs/guides/bleed.mdx
@@ -1,0 +1,261 @@
+---
+description: What chart bleed is and how to use it to align multiple charts
+---
+
+import React from 'react'
+import BrowserOnly from '@docusaurus/BrowserOnly'
+import { FrameworkTabs } from '../components/framework-tabs.tsx'
+import { generateDataRecords } from '../utils/data.ts'
+import { XYWrapper } from '../wrappers/xy-wrapper'
+
+import './styles.css'
+
+# Bleed
+
+export const data = generateDataRecords(15)
+export const axes = [
+  { name: 'Axis', props: { type: 'x' }, key: 'xAxis' },
+  { name: 'Axis', props: { type: 'y' }, key: 'yAxis' },
+]
+export const scatterProps = {
+  name: 'Scatter',
+  data,
+  height: 125,
+  x: d => d.x,
+  y: d => d.y,
+  size: 25,
+  excludeTabs: true,
+  components: axes,
+}
+
+## What is bleed?
+Some _XY Components_ need extra space inside the container for their marks to fully fit: half of the
+point diameter for _Scatter_, half of the bar width for bar charts at the edges of the domain, and so on.
+This space is called **bleed**. Before rendering, _XY Container_ asks every component how much bleed it
+needs, combines the values (taking the maximum for each side), and shrinks the scale ranges accordingly.
+
+That's why the first and the last points of the scatter chart below are shifted inward from the
+container's edges instead of being cut in half:
+
+<XYWrapper {...scatterProps}/>
+
+## Overriding the calculated bleed
+The `bleed` property of _XY Container_ lets you override the calculated values. It accepts either
+a `Spacing` object:
+
+```ts
+type Spacing = { top?: number; bottom?: number; left?: number; right?: number }
+```
+
+or a function that receives the container's components and returns a `Spacing` object (each component's
+own bleed is available via its `bleed` getter):
+
+```ts
+bleed: (components: XYComponentCore<Datum>[]) => Spacing
+```
+
+The sides you provide replace the calculated values, the sides left `undefined` fall back to them, so
+pass `0` explicitly to remove the bleed on a side. Here is the same scatter chart with the bleed set to
+zero on all sides — the edge points now get clipped:
+
+<XYWrapper {...scatterProps} containerProps={{ bleed: { top: 0, bottom: 0, left: 0, right: 0 } }}/>
+
+## Reading the calculated bleed
+The container reports the bleed it ended up using (calculated or configured) through the
+`onRenderComplete` callback:
+
+```ts
+onRenderComplete?: (
+  svgNode: SVGSVGElement,
+  margin: Spacing,
+  bleed: Spacing,
+  containerWidth: number,
+  containerHeight: number,
+  componentWidth: number,
+  componentHeight: number,
+) => void;
+```
+
+## Synchronizing bleed across charts
+Bleed becomes important when you place several charts one below another and want their X values to line
+up. Even if the charts share the same `xDomain`, each one calculates its own bleed, so the same X value
+can land on a different horizontal position in every chart.
+
+To align them, you only need to synchronize the horizontal bleed: capture the `left` and `right` values
+of the chart with the largest marks (or the per-side maximum across all charts) from `onRenderComplete`,
+and pass them to the other charts via the `bleed` property. Leave `top` and `bottom` out — they fall back
+to each chart's own calculated values. Toggle the checkbox below to see the effect — watch how the X axes
+of the two charts align:
+
+<BrowserOnly>
+{() => {
+  const { VisXYContainer, VisScatter, VisLine, VisAxis } = require('@unovis/react')
+  const [sync, setSync] = React.useState(true)
+  const [horizontalBleed, setHorizontalBleed] = React.useState()
+  const onRenderComplete = React.useCallback((svg, margin, b) => {
+    setHorizontalBleed(prev => (prev && prev.left === b.left && prev.right === b.right) ? prev : { left: b.left, right: b.right })
+  }, [])
+  const x = d => d.x
+  const y = d => d.y
+  return (
+    <div>
+      <label style={{ display: 'block', marginBottom: '12px' }}>
+        <input type='checkbox' checked={sync} onChange={e => setSync(e.target.checked)}/>
+        &nbsp;Synchronize bleed
+      </label>
+      <VisXYContainer data={data} height={125} onRenderComplete={onRenderComplete}>
+        <VisScatter x={x} y={y} size={25}/>
+        <VisAxis type='x'/>
+        <VisAxis type='y'/>
+      </VisXYContainer>
+      <VisXYContainer data={data} height={125} bleed={sync ? horizontalBleed : undefined}>
+        <VisLine x={x} y={y}/>
+        <VisAxis type='x'/>
+        <VisAxis type='y'/>
+      </VisXYContainer>
+    </div>
+  )
+}}
+</BrowserOnly>
+
+<FrameworkTabs
+  react={`import { useCallback, useState } from 'react'
+import { VisXYContainer, VisScatter, VisLine, VisAxis } from '@unovis/react'
+
+function SyncedCharts ({ data }) {
+  const [horizontalBleed, setHorizontalBleed] = useState()
+  const onRenderComplete = useCallback((svg, margin, b) => {
+    setHorizontalBleed(prev => (prev?.left === b.left && prev?.right === b.right)
+      ? prev
+      : { left: b.left, right: b.right })
+  }, [])
+
+  // Synchronize the horizontal bleed only, the vertical values fall back to the calculated ones
+  return (<>
+    <VisXYContainer data={data} onRenderComplete={onRenderComplete}>
+      <VisScatter x={d => d.x} y={d => d.y} size={25}/>
+      <VisAxis type='x'/>
+    </VisXYContainer>
+    <VisXYContainer data={data} bleed={horizontalBleed}>
+      <VisLine x={d => d.x} y={d => d.y}/>
+      <VisAxis type='x'/>
+    </VisXYContainer>
+  </>)
+}`}
+  angular={{
+    ts: `x = (d: DataRecord) => d.x
+y = (d: DataRecord) => d.y
+horizontalBleed?: Spacing
+
+// Synchronize the horizontal bleed only, the vertical values fall back to the calculated ones
+onRenderComplete = (svg: SVGSVGElement, margin: Spacing, bleed: Spacing): void => {
+  this.horizontalBleed = { left: bleed.left, right: bleed.right }
+}`,
+    html: `<vis-xy-container [data]="data" [onRenderComplete]="onRenderComplete">
+  <vis-scatter [x]="x" [y]="y" [size]="25"></vis-scatter>
+  <vis-axis type="x"></vis-axis>
+</vis-xy-container>
+<vis-xy-container [data]="data" [bleed]="horizontalBleed">
+  <vis-line [x]="x" [y]="y"></vis-line>
+  <vis-axis type="x"></vis-axis>
+</vis-xy-container>`,
+  }}
+  svelte={`<script lang='ts'>
+  let horizontalBleed: Spacing | undefined
+
+  // Synchronize the horizontal bleed only, the vertical values fall back to the calculated ones
+  const onRenderComplete = (svg: SVGSVGElement, margin: Spacing, b: Spacing) => {
+    if (horizontalBleed?.left !== b.left || horizontalBleed?.right !== b.right) {
+      horizontalBleed = { left: b.left, right: b.right }
+    }
+  }
+</script>
+
+<VisXYContainer {data} {onRenderComplete}>
+  <VisScatter x={d => d.x} y={d => d.y} size={25}/>
+  <VisAxis type='x'/>
+</VisXYContainer>
+<VisXYContainer {data} bleed={horizontalBleed}>
+  <VisLine x={d => d.x} y={d => d.y}/>
+  <VisAxis type='x'/>
+</VisXYContainer>`}
+  vue={`<script setup lang='ts'>
+import { ref } from 'vue'
+const horizontalBleed = ref<Spacing>()
+
+// Synchronize the horizontal bleed only, the vertical values fall back to the calculated ones
+const onRenderComplete = (svg: SVGSVGElement, margin: Spacing, b: Spacing) => {
+  if (horizontalBleed.value?.left !== b.left || horizontalBleed.value?.right !== b.right) {
+    horizontalBleed.value = { left: b.left, right: b.right }
+  }
+}
+</script>
+
+<template>
+  <VisXYContainer :data="data" :onRenderComplete="onRenderComplete">
+    <VisScatter :x="d => d.x" :y="d => d.y" :size="25"/>
+    <VisAxis type="x"/>
+  </VisXYContainer>
+  <VisXYContainer :data="data" :bleed="horizontalBleed">
+    <VisLine :x="d => d.x" :y="d => d.y"/>
+    <VisAxis type="x"/>
+  </VisXYContainer>
+</template>`}
+  solid={`import { createSignal } from 'solid-js'
+import { VisXYContainer, VisScatter, VisLine, VisAxis } from '@unovis/solid'
+
+function SyncedCharts (props) {
+  const [horizontalBleed, setHorizontalBleed] = createSignal<Spacing>()
+
+  // Synchronize the horizontal bleed only, the vertical values fall back to the calculated ones
+  const onRenderComplete = (svg: SVGSVGElement, margin: Spacing, b: Spacing) => {
+    const prev = horizontalBleed()
+    if (prev?.left !== b.left || prev?.right !== b.right) {
+      setHorizontalBleed({ left: b.left, right: b.right })
+    }
+  }
+
+  return (<>
+    <VisXYContainer data={props.data} onRenderComplete={onRenderComplete}>
+      <VisScatter x={d => d.x} y={d => d.y} size={25}/>
+      <VisAxis type='x'/>
+    </VisXYContainer>
+    <VisXYContainer data={props.data} bleed={horizontalBleed()}>
+      <VisLine x={d => d.x} y={d => d.y}/>
+      <VisAxis type='x'/>
+    </VisXYContainer>
+  </>)
+}`}
+  typescript={`import { XYContainer, Scatter, Line, Axis, Spacing } from '@unovis/ts'
+
+const lineChart = new XYContainer(lineChartNode, {
+  components: [new Line({ x: d => d.x, y: d => d.y })],
+  xAxis: new Axis(),
+}, data)
+
+const scatterChart = new XYContainer(scatterChartNode, {
+  components: [new Scatter({ x: d => d.x, y: d => d.y, size: 25 })],
+  xAxis: new Axis(),
+  onRenderComplete: (svg, margin, bleed) => {
+    // Synchronize the horizontal bleed only, the vertical values fall back to the calculated ones
+    lineChart.updateContainer({
+      ...lineChart.config,
+      bleed: { left: bleed.left, right: bleed.right },
+    })
+  },
+}, data)`}
+/>
+
+:::tip
+For the charts to align perfectly, their `margin` values need to match too. If the Y axes of your charts
+have tick labels of different widths, the automatically calculated margins will differ — set
+`autoMargin` to `false` and provide the same explicit [`margin`](/docs/containers/XY_Container#margin)
+to all the charts.
+:::
+
+:::note
+`onRenderComplete` reports the bleed the container actually used, so when you override `bleed` it reports
+your values on the sides you provided and the calculated ones on the sides you left out. If you need the
+components' calculated bleed for a side you're overriding, use the function form of `bleed` and read the
+`bleed` getter of the components you're interested in.
+:::


### PR DESCRIPTION
https://github.com/f5/unovis/pull/861

Accepts a `Spacing` object or a function receiving the container's components, and replaces the automatically calculated bleed entirely (undefined sides fallback to the calculated bleed). Together with the bleed reported by `onRenderComplete`, this allows synchronizing the scale ranges of multiple charts placed one below another.


https://github.com/user-attachments/assets/3687b9ea-e7ac-4ba8-8cde-8038813b2540

