### PR TITLE
Component | Donut: A new minSegmentAngle config option

### DIFF
--- a/packages/angular/src/components/donut/donut.component.ts
+++ b/packages/angular/src/components/donut/donut.component.ts
@@ -83,6 +83,14 @@ export class VisDonutComponent<Datum> implements DonutConfigInterface<Datum>, Af
   /** Pad angle. Default: `0` */
   @Input() padAngle?: number
 
+  /** Minimum angular sweep, in radians, for any segment with a positive value.
+   * Segments whose proportional sweep would be smaller are inflated to this angle,
+   * with the difference taken proportionally from the remaining segments.
+   * Guarantees a segment can survive the `padAngle` inset instead of collapsing
+   * to a zero-area path; a sensible setting is `minSegmentAngle >= 2 * padAngle`.
+   * Default: `undefined` */
+  @Input() minSegmentAngle?: number
+
   /** Custom sort function. Default: `undefined` */
   @Input() sortFunction?: (a: Datum, b: Datum) => number
 
@@ -152,8 +160,8 @@ export class VisDonutComponent<Datum> implements DonutConfigInterface<Datum>, Af
   }
 
   private getConfig (): DonutConfigInterface<Datum> {
-    const { duration, events, attributes, id, value, angleRange, padAngle, sortFunction, cornerRadius, color, pattern, radius, arcWidth, centralLabel, centralSubLabel, centralSubLabelWrap, showEmptySegments, emptySegmentAngle, showBackground, backgroundAngleRange, centralLabelOffsetX, centralLabelOffsetY } = this
-    const config = { duration, events, attributes, id, value, angleRange, padAngle, sortFunction, cornerRadius, color, pattern, radius, arcWidth, centralLabel, centralSubLabel, centralSubLabelWrap, showEmptySegments, emptySegmentAngle, showBackground, backgroundAngleRange, centralLabelOffsetX, centralLabelOffsetY }
+    const { duration, events, attributes, id, value, angleRange, padAngle, minSegmentAngle, sortFunction, cornerRadius, color, pattern, radius, arcWidth, centralLabel, centralSubLabel, centralSubLabelWrap, showEmptySegments, emptySegmentAngle, showBackground, backgroundAngleRange, centralLabelOffsetX, centralLabelOffsetY } = this
+    const config = { duration, events, attributes, id, value, angleRange, padAngle, minSegmentAngle, sortFunction, cornerRadius, color, pattern, radius, arcWidth, centralLabel, centralSubLabel, centralSubLabelWrap, showEmptySegments, emptySegmentAngle, showBackground, backgroundAngleRange, centralLabelOffsetX, centralLabelOffsetY }
     const keys = Object.keys(config) as (keyof DonutConfigInterface<Datum>)[]
     keys.forEach(key => { if (config[key] === undefined) delete config[key] })
 

--- a/packages/dev/src/examples/misc/donut/donut-min-segment-angle/index.tsx
+++ b/packages/dev/src/examples/misc/donut/donut-min-segment-angle/index.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { VisSingleContainer, VisDonut } from '@unovis/react'
+import { ExampleViewerDurationProps } from '@src/components/ExampleViewer/index'
+
+export const title = 'Donut: Minimum Segment Angle'
+export const subTitle = 'Tiny segments survive the pad inset'
+
+export const component = (props: ExampleViewerDurationProps): React.ReactNode => {
+  const data = [6800, 2400, 790, 14, 10, 7, 5]
+  return (
+    <div style={{ display: 'flex' }}>
+      <VisSingleContainer height={400} style={{ flex: 1, minWidth: 0 }}>
+        <VisDonut
+          value={d => d}
+          data={data}
+          padAngle={0.02}
+          arcWidth={60}
+          centralLabel={'padAngle: 0.02'}
+          centralSubLabel={'the tiny segments collapse'}
+          duration={props.duration}
+        />
+      </VisSingleContainer>
+      <VisSingleContainer height={400} style={{ flex: 1, minWidth: 0 }}>
+        <VisDonut
+          value={d => d}
+          data={data}
+          padAngle={0.02}
+          minSegmentAngle={0.08}
+          arcWidth={60}
+          centralLabel={'minSegmentAngle: 0.08'}
+          centralSubLabel={'the tiny segments survive'}
+          duration={props.duration}
+        />
+      </VisSingleContainer>
+    </div>
+  )
+}

--- a/packages/ts/src/components/donut/config.ts
+++ b/packages/ts/src/components/donut/config.ts
@@ -14,6 +14,13 @@ export interface DonutConfigInterface<Datum> extends ComponentConfigInterface {
   angleRange?: [number, number];
   /** Pad angle. Default: `0` */
   padAngle?: number;
+  /** Minimum angular sweep, in radians, for any segment with a positive value.
+   * Segments whose proportional sweep would be smaller are inflated to this angle,
+   * with the difference taken proportionally from the remaining segments.
+   * Guarantees a segment can survive the `padAngle` inset instead of collapsing
+   * to a zero-area path; a sensible setting is `minSegmentAngle >= 2 * padAngle`.
+   * Default: `undefined` */
+  minSegmentAngle?: number;
   /** Custom sort function. Default: `undefined` */
   sortFunction?: (a: Datum, b: Datum) => number;
   /** Corner Radius. Default: `0` */
@@ -60,6 +67,7 @@ export const DonutDefaultConfig: DonutConfigInterface<unknown> = {
   value: undefined,
   angleRange: [0, 2 * Math.PI],
   padAngle: 0,
+  minSegmentAngle: undefined,
   sortFunction: undefined,
   cornerRadius: 0,
   color: undefined,

--- a/packages/ts/src/components/donut/index.ts
+++ b/packages/ts/src/components/donut/index.ts
@@ -24,6 +24,9 @@ import { DonutDefaultConfig, DonutConfigInterface } from './config'
 // Modules
 import { createArc, updateArc, removeArc, ArcNode } from './modules/arc'
 
+// Local Utils
+import { applyMinSegmentAngle } from './utils'
+
 // Constants
 import { DONUT_HALF_ANGLE_RANGES } from './constants'
 
@@ -126,7 +129,15 @@ export class Donut<Datum> extends ComponentCore<Datum[], DonutConfigInterface<Da
       .value(d => getNumber(d.datum, config.value, d.index) || 0)
       .sort((a, b) => config.sortFunction?.(a.datum, b.datum))
 
-    const arcData: DonutArcDatum<Datum>[] = pieGen(data).map(d => {
+    const pieData = pieGen(data)
+    if (isNumber(config.minSegmentAngle)) {
+      applyMinSegmentAngle(pieData, config.minSegmentAngle, [
+        config.angleRange?.[0] ?? 0,
+        config.angleRange?.[1] ?? 2 * Math.PI,
+      ])
+    }
+
+    const arcData: DonutArcDatum<Datum>[] = pieData.map(d => {
       const arc = {
         ...d,
         data: d.data.datum,

--- a/packages/ts/src/components/donut/utils.ts
+++ b/packages/ts/src/components/donut/utils.ts
@@ -1,0 +1,63 @@
+import { PieArcDatum } from 'd3-shape'
+
+/** Inflates positive-value arcs whose sweep is smaller than `minSegmentAngle`,
+ * taking the difference proportionally from the remaining positive arcs.
+ * Mutates the arc angles in place; input values stay untouched. */
+export function applyMinSegmentAngle<Datum> (
+  arcs: PieArcDatum<Datum>[],
+  minSegmentAngle: number,
+  angleRange: [number, number]
+): void {
+  if (!arcs.length) return
+
+  // d3's pie gives every arc an extra `padAngle` of sweep on top of its
+  // value-proportional share, so the redistribution operates on the
+  // pad-free ("content") part of each sweep
+  const padAngle = arcs[0].padAngle
+  const totalAngle = angleRange[1] - angleRange[0]
+  const contentAngle = totalAngle - arcs.length * padAngle
+  const minContentAngle = minSegmentAngle - padAngle
+  if (contentAngle <= 0 || minContentAngle <= 0) return
+
+  const positiveArcs = arcs.filter(arc => arc.value > 0)
+  const getRemainingValue = (inflated: Set<PieArcDatum<Datum>>): number =>
+    positiveArcs.reduce((sum, arc) => inflated.has(arc) ? sum : sum + arc.value, 0)
+
+  // Settle the set of inflated arcs iteratively: inflating one arc shrinks
+  // the rest, which can push more arcs below the threshold. The set only
+  // grows, so the loop is bounded by the number of positive arcs
+  const inflated = new Set<PieArcDatum<Datum>>()
+  let hasChanged = true
+  while (hasChanged) {
+    hasChanged = false
+    const availableAngle = contentAngle - inflated.size * minContentAngle
+    const remainingValue = getRemainingValue(inflated)
+    for (const arc of positiveArcs) {
+      if (inflated.has(arc)) continue
+      const contentSweep = remainingValue > 0 ? availableAngle * arc.value / remainingValue : 0
+      if (contentSweep < minContentAngle) {
+        inflated.add(arc)
+        hasChanged = true
+      }
+    }
+  }
+  if (!inflated.size) return
+
+  // When the combined minimum exceeds the available range, scale the minimum
+  // down so the total still spans the range instead of overflowing it
+  const inflatedContentSweep = Math.min(minContentAngle, contentAngle / inflated.size)
+  const availableAngle = contentAngle - inflated.size * inflatedContentSweep
+  const remainingValue = getRemainingValue(inflated)
+
+  // Reassign the angles cumulatively, preserving the angular order of the layout
+  const orderedArcs = [...arcs].sort((a, b) => a.startAngle - b.startAngle)
+  let currentAngle = angleRange[0]
+  for (const arc of orderedArcs) {
+    const contentSweep = inflated.has(arc)
+      ? inflatedContentSweep
+      : (arc.value > 0 ? availableAngle * arc.value / remainingValue : 0)
+    arc.startAngle = currentAngle
+    arc.endAngle = currentAngle + contentSweep + padAngle
+    currentAngle = arc.endAngle
+  }
+}

--- a/packages/website/docs/misc/Donut.mdx
+++ b/packages/website/docs/misc/Donut.mdx
@@ -107,6 +107,16 @@ Providing a value to the `cornerRadius` property adds rounded corners to your _D
 Pad each segment with the `padAngle` property.
 <DocWrapper {...donutProps()} padAngle={0.1}/>
 
+### Minimum Segment Angle
+When `padAngle` is set, segments with a very small (but non-zero) value can collapse to a zero-area
+path and disappear, because the pad inset consumes their entire angular sweep. Provide a
+`minSegmentAngle` (in radians) to guarantee every segment with a positive value keeps at least that
+sweep, with the difference taken proportionally from the remaining segments. The raw values reported
+by tooltips and events stay untouched. For the inflated segments to stay visible, set
+`minSegmentAngle` to at least `2 * padAngle`. Try changing the value below — at `0` the four
+smallest segments disappear:
+<InputWrapper {...donutProps()} data={[6800, 2400, 790, 14, 10, 7, 5]} padAngle={0.02} property="minSegmentAngle" inputType="range" defaultValue={0.04} inputProps={{ min: 0, max: 0.15, step: 0.005 }}/>
+
 ### Empty Segments
 When segments are empty (i.e. when their values are 0), you may still want them displayed in your _Donut_ as thin slices.
 To do this, set `showEmptySegments` to `true`:


### PR DESCRIPTION
https://github.com/f5/unovis/pull/885

Adds a new `minSegmentAngle` config option to `Donut`

## Problem

`Donut` applies `padAngle` at every segment boundary, and d3's arc generator insets both ends
of each arc by more than `padAngle / 2` (its default `padRadius` exceeds either radius). Any
segment with a small non-zero value whose proportional sweep is smaller than that inset
collapses to a zero-area path and silently disappears, exposing the donut background.

Reproduction: `data = [6800, 2400, 790, 10]` with `padAngle: 0.02` — the `10` segment doesn't
render. The existing `showEmptySegments` / `emptySegmentAngle` mechanism only catches
exact-zero values, so tiny non-zero segments fall through.

## Solution

`minSegmentAngle` (radians, default `undefined` = current behavior) guarantees a minimum
angular sweep for every segment with a positive value:

- Inflation happens in angle space after the pie layout — `datum.value`, events, tooltips,
  and legend items keep reporting the raw input values.
- The inflated angle is taken proportionally from the remaining segments; the set of inflated
  segments is settled iteratively, since inflating one segment can push the next-smallest
  below the threshold.
- If the combined minimum exceeds the angle range, the minimum is scaled down so the total
  still spans `angleRange` (works with half donuts).
- Zero/negative values keep the existing `showEmptySegments` handling unchanged.
- A sensible setting is `minSegmentAngle >= 2 * padAngle` (documented in the prop's JSDoc);
  the two options are not implicitly coupled.

- [x] Dev examples
- [x] Wrappers
- [ ] Gallery example (not applicable)
- [x] Docs (includes an interactive `minSegmentAngle` slider example)

<img width="1506" height="458" alt="SCR-20260817-ixbf" src="https://github.com/user-attachments/assets/c37dc340-cec7-4444-8874-8adcb2abff30" />

https://github.com/user-attachments/assets/cd67f2c9-b813-4317-9dff-5c0abdcf070c



